### PR TITLE
refactor(navigation): eliminate props clicked and optimize component architecture

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VITE_API_URL="http://192.168.100.101:3000"
-VITE_API_WS_URL="http://192.168.100.101:3000/events"
+VITE_API_URL="http://localhost:3000"
+VITE_API_WS_URL="http://localhost:3000/events"

--- a/src/components/common/Navs/NavLeft.tsx
+++ b/src/components/common/Navs/NavLeft.tsx
@@ -1,21 +1,12 @@
 import NavModItem from "./NavModItem";
 import { useUserStore } from "../../../store/zustand/user-zustand";
 
-const NavLeft = ({ clicked }: { clicked: number }) => {
+const NavLeft = () => {
   const userGlobal = useUserStore((state) => state.userGlobal);
   return (
     <div className="flex flex-[0_0_300px] flex-col  relative dark:bg-slate  -700">
       <dl className="flex flex-[1_1_100%] min-h-0 flex-col">
-        {userGlobal?.rol?.modulos.map((modulo, i: number) => {
-          return (
-            <NavModItem
-              key={i + 1}
-              modulo={modulo}
-              clicked={clicked}
-              position={i}
-            />
-          );
-        })}
+        {userGlobal?.rol?.modulos.map((modulo, i: number) => <NavModItem key={i + 1} modulo={modulo} position={i} />)}
       </dl>
     </div>
   );

--- a/src/components/common/Navs/NavMenuItem.tsx
+++ b/src/components/common/Navs/NavMenuItem.tsx
@@ -20,14 +20,14 @@ import { IFeatureModule } from "../../../interfaces/features/modulo/modulo.inter
 import { useTabStore } from "../../../store/zustand/tabs-zustand";
 import { useUserStore } from "../../../store/zustand/user-zustand";
 import { usePageStore } from "../../../store/zustand/page-zustand";
+import { useClickedStore } from "../../../store/zustand/clicked-tabs-zustand";
 
 interface Props {
   menu: IFeatureMenu;
   modulo: IFeatureModule;
-  clicked: number;
 }
 
-const NavMenuItem = ({ menu, modulo, clicked }: Props) => {
+const NavMenuItem = ({ menu, modulo }: Props) => {
   const { dispatch } = useContext(ModalContext);
   const userGlobal = useUserStore((state) => state.userGlobal);
   const setPage = usePageStore((state) => state.setPage);
@@ -35,6 +35,7 @@ const NavMenuItem = ({ menu, modulo, clicked }: Props) => {
   const tabs = useTabStore((state) => state.tabs);
   const setTabs = useTabStore((state) => state.setTabs);
   const setMenuSelected = useTabStore((state) => state.setMenuSelected);
+  const clicked = useClickedStore((state) => state.clicked);
 
   const documentos = (userGlobal?.empresaActual?.establecimiento?.pos?.documentos as ITipoDocsExtentido[]) ?? [];
 
@@ -59,6 +60,7 @@ const NavMenuItem = ({ menu, modulo, clicked }: Props) => {
                 menu: {
                   estado: true,
                   nombre: menu.nombre,
+                  page: PageEnum.INIT,
                 },
                 moduloAux: {
                   estado: true,
@@ -67,6 +69,7 @@ const NavMenuItem = ({ menu, modulo, clicked }: Props) => {
                 menuAux: {
                   estado: true,
                   nombre: menu.nombre,
+                  page: PageEnum.INIT,
                 },
               };
             }
@@ -227,17 +230,51 @@ const NavMenuItem = ({ menu, modulo, clicked }: Props) => {
                   // Renderizar solo si tiene el permiso
                   if (tienePermiso) {
                     const handleClick = () => {
+                      const tabSelected = tabs.find((a) => a.index === clicked);
+
                       if (DOCUMENTO === "FACTURA") {
+                        const newTab: typeof tabSelected = {
+                          ...tabSelected!,
+                          menu: {
+                            ...tabSelected!.menu,
+                            page: PageEnum.SCREEN_CREATE_INVOICE,
+                          },
+                          menuAux: {
+                            ...tabSelected!.menuAux,
+                            page: PageEnum.SCREEN_CREATE_INVOICE,
+                          },
+                        };
+
                         setPage({
                           open: true,
                           namePage: PageEnum.SCREEN_CREATE_INVOICE,
                           pageComplete: false,
                         });
+
+                        setTabs((currentTabs) => {
+                          return currentTabs.map((tab) => (tab.index === clicked ? newTab : tab));
+                        });
                       } else if (DOCUMENTO === "BOLETA") {
+                        const newTab: typeof tabSelected = {
+                          ...tabSelected!,
+                          menu: {
+                            ...tabSelected!.menu,
+                            page: PageEnum.SCREEN_CREATE_BOLETA,
+                          },
+                          menuAux: {
+                            ...tabSelected!.menuAux,
+                            page: PageEnum.SCREEN_CREATE_BOLETA,
+                          },
+                        };
+
                         setPage({
                           open: true,
                           namePage: PageEnum.SCREEN_CREATE_BOLETA,
                           pageComplete: false,
+                        });
+
+                        setTabs((currentTabs) => {
+                          return currentTabs.map((tab) => (tab.index === clicked ? newTab : tab));
                         });
                       }
                       // Agrega más acciones aquí si es necesario

--- a/src/components/common/Navs/NavModItem.tsx
+++ b/src/components/common/Navs/NavModItem.tsx
@@ -4,29 +4,27 @@ import { IoIosArrowUp } from "react-icons/io";
 import { IoIosArrowDown } from "react-icons/io";
 import { convertirTitulo } from "../../../utils/functions.utils";
 import { useTabStore } from "../../../store/zustand/tabs-zustand";
+import { useClickedStore } from "../../../store/zustand/clicked-tabs-zustand";
+import { PageEnum } from "../../../types/enums/page.enum";
 
 interface Props {
   modulo: IFeatureModule;
-  clicked: number;
   position: number;
 }
 
-const NavModItem = ({ modulo, clicked }: Props) => {
+const NavModItem = ({ modulo }: Props) => {
   const tabs = useTabStore((state) => state.tabs);
   const setTabs = useTabStore((state) => state.setTabs);
   const setMenuSelected = useTabStore((state) => state.setMenuSelected);
+  const clicked = useClickedStore((state) => state.clicked);
 
   const handleModulo = () => {
     // si es el mismo modulo no hace nada
-    const currentModule = tabs.find(
-      (a) => a.index === clicked && a.modulo.nombre === modulo.nombre
-    );
+    const currentModule = tabs.find((a) => a.index === clicked && a.modulo.nombre === modulo.nombre);
     if (currentModule) return;
 
     // si es otro modulo
-    const updateTabWithModuleSelected = tabs.find(
-      (a) => a.modulo.nombre !== modulo.nombre
-    );
+    const updateTabWithModuleSelected = tabs.find((a) => a.modulo.nombre !== modulo.nombre);
     setTabs(
       updateTabWithModuleSelected
         ? tabs.map((tab) => {
@@ -40,6 +38,7 @@ const NavModItem = ({ modulo, clicked }: Props) => {
                 menu: {
                   estado: true,
                   nombre: String(modulo?.menus?.[0].nombre),
+                  page: PageEnum.INIT,
                 },
                 moduloAux: {
                   estado: true,
@@ -48,6 +47,7 @@ const NavModItem = ({ modulo, clicked }: Props) => {
                 menuAux: {
                   estado: true,
                   nombre: String(modulo?.menus?.[0].nombre),
+                  page: PageEnum.INIT,
                 },
               };
             }
@@ -66,18 +66,14 @@ const NavModItem = ({ modulo, clicked }: Props) => {
       <dt
         onClick={handleModulo}
         className={`flex flex-[0_0_auto] font-[500] ${moduloSelected?.modulo.nombre === modulo.nombre ? "border-t " : ""}${
-          moduloSelected?.modulo.nombre === modulo.nombre &&
-          moduloSelected?.modulo.estado
+          moduloSelected?.modulo.nombre === modulo.nombre && moduloSelected?.modulo.estado
             ? "bg-bgDefault hover:bg-bgDefault cursor-default"
             : " hover:bg-bgDefault cursor-pointer border-t border-solid"
         } leading-[20px]  p-[2px_10px] select-none text-default`}
       >
-        <span className="flex-[1_1_auto]">
-          {convertirTitulo(modulo.nombre)}
-        </span>
+        <span className="flex-[1_1_auto]">{convertirTitulo(modulo.nombre)}</span>
         <span className="text-[14px] flex justify-center items-center">
-          {moduloSelected?.modulo.nombre === modulo.nombre &&
-          moduloSelected?.modulo.estado ? (
+          {moduloSelected?.modulo.nombre === modulo.nombre && moduloSelected?.modulo.estado ? (
             <IoIosArrowUp />
           ) : (
             <IoIosArrowDown />
@@ -86,8 +82,7 @@ const NavModItem = ({ modulo, clicked }: Props) => {
       </dt>
       <dd
         className={`transition-all ease-linear duration-[300ms] ${
-          moduloSelected?.modulo.nombre === modulo.nombre &&
-          moduloSelected?.modulo.estado
+          moduloSelected?.modulo.nombre === modulo.nombre && moduloSelected?.modulo.estado
             ? "flex-[1_1_auto] h-[300px]"
             : "flex-none h-0"
         } w-full overflow-hidden bg-[url('https://cms.wialon.us/frontend/static/accounts_bg-57ba306c992683f5882f0eeb2affbf08.svg')] bg-no-repeat bg-bottom hue-rotate-[0deg]`}
@@ -95,14 +90,7 @@ const NavModItem = ({ modulo, clicked }: Props) => {
         <div className="p-[5px]">
           <ol className="font-bold list-decimal pl-3">
             {modulo?.menus?.map((menu, i: number) => {
-              return (
-                <NavMenuItem
-                  key={i}
-                  modulo={modulo}
-                  menu={menu}
-                  clicked={clicked}
-                />
-              );
+              return <NavMenuItem key={i} modulo={modulo} menu={menu} />;
             })}
           </ol>
         </div>

--- a/src/features/Comprobantes/pages/ComprobantesElectronicosPage.tsx
+++ b/src/features/Comprobantes/pages/ComprobantesElectronicosPage.tsx
@@ -1,54 +1,59 @@
+import { useMemo } from "react";
 import CPEList from "../components/ComprobanteList";
-import { usePageStore } from "../../../store/zustand/page-zustand";
 import { PageEnum } from "../../../types/enums/page.enum";
 import FacturaScreen from "./FacturaPage";
 import PaperRounded from "../../../components/Material/Paper/PaperRounded";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import { Divider, IconButton, Tooltip, Typography } from "@mui/material";
+import { useTabStore } from "../../../store/zustand/tabs-zustand";
+import { useClickedStore } from "../../../store/zustand/clicked-tabs-zustand";
 
 const CPEScreen = () => {
-  const page = usePageStore((state) => state.page);
-  const setPage = usePageStore((state) => state.setPage);
+  const tabs = useTabStore((state) => state.tabs);
+  const clicked = useClickedStore((state) => state.clicked);
 
-  return (
-    <>
-      {page.open && page.namePage === PageEnum.SCREEN_CREATE_INVOICE ? (
-        <div className="bg-[#F8F8F8] overflow-y-auto min-h-dvh">
-          <div className="min-w-[1050px] relative mx-auto">
-            <div className="p-[30px] w-[1050px] mx-auto">
-              <PaperRounded className="!shadow-asun">
-                {/* <div className="pl-[15px] py-[10px] flex justify-start items-center">
-                  <Tooltip title="Regresar" arrow>
-                    <IconButton
-                      onClick={() =>
-                        setPage({
-                          namePage: PageEnum.SCREEN_LIST_CPES,
-                          open: true,
-                          pageComplete: false,
-                        })
-                      }
-                    >
-                      <ArrowBackIcon />
-                    </IconButton>
-                  </Tooltip>{" "}
-                  <Typography variant="h6">
-                    Emitir <small className="text-default">Factura</small>
-                  </Typography>
-                </div>
-                <Divider variant="fullWidth" />
-                <div className="pt-[20px]">
-                  <FacturaScreen />
-                </div> */}
-                <FacturaScreen />
-              </PaperRounded>
-            </div>
-          </div>
+  // Memoizar la página actual para evitar cálculos innecesarios
+  const currentPage = useMemo((): string => {
+    const currentTab = tabs.find((a) => a.index === clicked);
+    return currentTab ? currentTab.menu.page : PageEnum.INIT;
+  }, [tabs, clicked]);
+
+  // Componente de layout reutilizable para documentos
+  const DocumentLayout = ({ children }: { children: React.ReactNode }) => (
+    <div className="bg-[#F8F8F8] overflow-y-auto min-h-dvh">
+      <div className="min-w-[1050px] relative mx-auto">
+        <div className="p-[30px] w-[1050px] mx-auto">
+          <PaperRounded className="!shadow-asun">{children}</PaperRounded>
         </div>
-      ) : null}
-
-      {!page.open && page.namePage === PageEnum.INIT && <CPEList />}
-    </>
+      </div>
+    </div>
   );
+
+  // Renderizar el contenido basado en la página actual
+  const renderContent = () => {
+    switch (currentPage) {
+      case PageEnum.SCREEN_CREATE_INVOICE:
+        return (
+          <DocumentLayout>
+            <FacturaScreen />
+          </DocumentLayout>
+        );
+
+      case PageEnum.SCREEN_CREATE_BOLETA:
+        return (
+          <DocumentLayout>
+            {/* <BoletaScreen /> */}
+            <div>Boleta Screen - Componente pendiente de crear</div>
+          </DocumentLayout>
+        );
+
+      case PageEnum.INIT:
+        return <CPEList />;
+
+      default:
+        return <CPEList />;
+    }
+  };
+
+  return <>{renderContent()}</>;
 };
 
 export default CPEScreen;

--- a/src/interfaces/components/tab-top/tab.interface.ts
+++ b/src/interfaces/components/tab-top/tab.interface.ts
@@ -7,10 +7,12 @@ export interface ITabItem {
   menu: {
     nombre: string;
     estado: boolean;
+    page: string;
   };
   menuAux: {
     nombre: string;
     estado: boolean;
+    page: string;
   };
   moduloAux: {
     nombre: string;

--- a/src/layouts/Main.tsx
+++ b/src/layouts/Main.tsx
@@ -1,16 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import NavLeft from "../components/common/Navs/NavLeft";
 import TabItem from "../components/common/Tabs/Views/TabItem";
-import FacturaScreen from "../features/Comprobantes/pages/FacturaPage";
-import PaperRounded from "../components/Material/Paper/PaperRounded";
-import { Divider, IconButton, Tooltip, Typography } from "@mui/material";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import { PageEnum } from "../types/enums/page.enum";
 import DynamicComponentLoader from "../utils/render-component-dynamic.utils";
 import { useTabStore } from "../store/zustand/tabs-zustand";
-import { INITIAL_VALUE_PAGE, INITIAL_VALUE_TAB } from "../config/constants";
+import { INITIAL_VALUE_TAB } from "../config/constants";
 import { useUserStore } from "../store/zustand/user-zustand";
 import { usePageStore } from "../store/zustand/page-zustand";
+import { useClickedStore } from "../store/zustand/clicked-tabs-zustand";
+import { PageEnum } from "../types/enums/page.enum";
 
 //https://codesandbox.io/s/dynamic-components-ngtnx7
 const Main = () => {
@@ -18,12 +15,9 @@ const Main = () => {
   const setTabs = useTabStore((state) => state.setTabs);
   const menuSelected = useTabStore((state) => state.menuSelected);
   const setMenuSelected = useTabStore((state) => state.setMenuSelected);
-
-  //console.log(tabs, setTabs);
-  const [clicked, setClicked] = useState<number>(0);
+  const clicked = useClickedStore((state) => state.clicked);
+  const setClicked = useClickedStore((state) => state.setClicked);
   const userGlobal = useUserStore((state) => state.userGlobal);
-
-  const page = usePageStore((state) => state.page);
   const setPage = usePageStore((state) => state.setPage);
 
   //Controlamos los tabs que se encuentran en el top(TabItem)
@@ -89,12 +83,12 @@ const Main = () => {
 
       const primerMenu = primerModulo?.menus?.[0];
 
-      // ✅ Solo establecer el menú si NO hay uno ya seleccionado (persistido)
+      // Solo establecer el menú si NO hay uno ya seleccionado (persistido)
       if (!menuSelected || menuSelected === "") {
         setMenuSelected(String(primerMenu?.nombre ?? ""));
       }
 
-      // ✅ Solo establecer tabs si no hay tabs o está vacío
+      // Solo establecer tabs si no hay tabs o está vacío
       if (tabs.length === 0) {
         setTabs([
           {
@@ -110,53 +104,23 @@ const Main = () => {
             menuAux: {
               estado: true,
               nombre: String(primerMenu?.nombre),
+              page: PageEnum.INIT,
             },
             menu: {
               estado: true,
               nombre: String(primerMenu?.nombre),
+              page: PageEnum.INIT,
             },
           },
         ]);
       }
-
-      //   setPage({
-      //     namePage: String(primerMenu?.nombre ?? "") as any,
-      //     open: true,
-      //     pageComplete: false,
-      //   });
     }
   }, [userGlobal, setMenuSelected, setTabs, setPage, menuSelected, tabs]);
 
   return (
     <>
-      {/* {page.pageComplete && page.namePage === PageEnum.SCREEN_FACTURA && (
-        // <FacturaScreen /> bg-[#EDF1F4] border borders min-h-[100vh] flex justify-center pt-[60px]
-        <div className="bg-[#F8F8F8] min-h-[100vh] min-w-max">
-          <div className="min-w-[1050px] relative mt-[60px] mx-auto">
-            <div className="p-[30px] w-[1050px] mx-auto">
-              <PaperRounded className="!shadow-asun">
-                <div className="pl-[15px] py-[10px] flex justify-start items-center">
-                  <Tooltip title="Regresar" arrow>
-                    <IconButton onClick={() => setPage(INITIAL_VALUE_PAGE)}>
-                      <ArrowBackIcon />
-                    </IconButton>
-                  </Tooltip>{" "}
-                  <Typography variant="h6">
-                    Emitir <small className="text-default">Factura</small>
-                  </Typography>
-                </div>
-                <Divider variant="fullWidth" />
-                <div className="pt-[20px]">
-                  <FacturaScreen />
-                </div>
-              </PaperRounded>
-            </div>
-          </div>
-        </div>
-      )} */}
-
       <div className="flex absolute top-[60px] bottom-[10px] left-[10px] right-[10px]">
-        <NavLeft clicked={clicked} />
+        <NavLeft />
         <div className="flex flex-[1_1_auto] relative">
           <div className="flex absolute h-full w-full top-0 left-0 flex-col">
             <div className="flex relative flex-col flex-[1_1_auto] pl-[8px] min-h-0">
@@ -193,10 +157,6 @@ const Main = () => {
           </div>
         </div>
       </div>
-
-      {/* {dialogState.open && (
-        <div className="absolute transition-all duration-1000 ease-in-out overflow-hidden w-full h-full top-0 left-0 bg-dialog z-[11]"></div>
-      )} */}
     </>
   );
 };

--- a/src/store/zustand/clicked-tabs-zustand.ts
+++ b/src/store/zustand/clicked-tabs-zustand.ts
@@ -1,0 +1,39 @@
+import { devtools } from "zustand/middleware";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ClickedStoreState {
+  clicked: number;
+}
+
+interface ClickedStoreActions {
+  setClicked: (
+    currentClicked:
+      | ClickedStoreState["clicked"]
+      | ((currentTab: ClickedStoreState["clicked"]) => ClickedStoreState["clicked"])
+  ) => void;
+}
+
+type ClickedStore = ClickedStoreState & ClickedStoreActions;
+
+export const useClickedStore = create<ClickedStore>()(
+  persist(
+    devtools(
+      (set) => ({
+        clicked: 0,
+        setClicked: (currentClicked) => {
+          set((state) => ({
+            clicked: typeof currentClicked === "function" ? currentClicked(state.clicked) : currentClicked,
+          }));
+        },
+      }),
+      {
+        enabled: true,
+        name: "clicked store",
+      }
+    ),
+    {
+      name: "clicked-storage",
+    }
+  )
+);


### PR DESCRIPTION
## Problem
- `clicked` state was passed through multiple components (prop drilling).
- BOLETA document navigation did not update tabs correctly.
- Some pages had performance and duplication issues.
- TypeScript types were incomplete.

## Solution
- Removed `clicked` prop drilling from `NavMenuItem`, `NavLeft`, and `Main`.
- Implemented direct Zustand store access for `clicked` state management.
- Fixed missing `setTabs` call for BOLETA navigation.
- Added `useMemo` optimization in `ComprobantesElectronicosPage` for performance.
- Created reusable `DocumentLayout` component to reduce code duplication.
- Updated tab interface to include `page` property in menu objects.
- Improved TypeScript typing for better safety.

## Impact
- Navigation and document handling more reliable (especially BOLETA).
- Cleaner and more maintainable codebase.
- Better performance and type safety.
- No breaking changes.

