### PR TITLE
fix: force websocket transport to avoid HTTP polling fallback

### DIFF
--- a/src/lib/socketsInstance.ts
+++ b/src/lib/socketsInstance.ts
@@ -11,6 +11,7 @@ const options: SocketOption = {
   reconnectionDelay: 1000,
   reconnectionDelayMax: 5000,
   timeout: 20000,
+  transports: ["websocket"],
 };
 
 // Singleton registry: one instance per namespace


### PR DESCRIPTION
## Summary
- Force socket connections to use WebSocket transport exclusively, removing the HTTP long-polling fallback

## Why
Socket.IO defaults to polling first, then upgrades to WebSocket. This causes unnecessary HTTP requests and latency on reconnections. Forcing `transports: ["websocket"]` ensures direct WebSocket connections from the start.

## Test plan
- [ ] Verificar que la conexión al servidor de sockets se establece correctamente
- [ ] Confirmar que no hay errores de conexión en consola
- [ ] Probar reconexión automática tras pérdida de red
